### PR TITLE
Removing population from data dictionary until we can support it again

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,6 @@ Data dictionary
     weekly normalized concentrations (effective
     genome copies per mL of wastewater)
 
--   population: sum of sewershed populations for all constituent
-    sampling locations, binned to preserve anonymity (str, categorical)
-
 -   region: the US Census region that each data point is associated
     with. These regions are derived from Census regions. (str,
     categorical)
@@ -167,9 +164,6 @@ Data dictionary
 -   effective\_concentration\_rolling\_average: three-sample, population-weighted average of
     weekly normalized concentrations (effective
     genome copies per mL of wastewater)
-
--   population: sum of sewershed populations for all constituent
-    sampling locations, binned to preserve anonymity (str, categorical)
 
 -   region: the US Census region that each data point is associated
     with. These regions are derived from Census regions (str,


### PR DESCRIPTION
We do not currently produce the population column in these files through our data pipeline, though they were included previously when the files were created by pandas notebooks, and when this data dictionary was created. Removing mention of these fields, while creating a ticket to bring them back into the data pipeline in the future.